### PR TITLE
moved over changes from skyux2 PR

### DIFF
--- a/src/app/public/modules/wait/fixtures/wait.component.fixture.html
+++ b/src/app/public/modules/wait/fixtures/wait.component.fixture.html
@@ -1,4 +1,17 @@
-<div class="sky-wait-test-component">
+<a
+  id="anchor-1"
+  href="#"
+>
+  Anchor tag 1
+</a>
+ <div class="sky-wait-test-component">
+  <button class='sky-btn sky-btn-primary'>I am button</button>
   <sky-wait [isWaiting]="isWaiting" [isFullPage]="isFullPage" [isNonBlocking]="isNonBlocking">
   </sky-wait>
 </div>
+ <a
+  id="anchor-2"
+  href="#"
+>
+  Anchor tag 2
+</a>

--- a/src/app/public/modules/wait/fixtures/wait.component.fixture.ts
+++ b/src/app/public/modules/wait/fixtures/wait.component.fixture.ts
@@ -1,7 +1,12 @@
 import {
   Component,
-  Input
+  Input,
+  ViewChild
 } from '@angular/core';
+
+import {
+  SkyWaitComponent
+} from '..';
 
 @Component({
   selector: 'sky-test-cmp',
@@ -16,4 +21,7 @@ export class SkyWaitTestComponent {
 
   @Input()
   public isNonBlocking: boolean;
+
+  @ViewChild(SkyWaitComponent)
+  public waitComponent: SkyWaitComponent;
 }

--- a/src/app/public/modules/wait/wait-adapter.service.ts
+++ b/src/app/public/modules/wait/wait-adapter.service.ts
@@ -1,13 +1,28 @@
 import {
   ElementRef,
   Injectable,
-  Renderer
+  Renderer,
+  OnDestroy
 } from '@angular/core';
+import {
+  SkyWindowRefService
+} from '@skyux/core';
 
 @Injectable()
-export class SkyWaitAdapterService {
+export class SkyWaitAdapterService implements OnDestroy {
+  private parentListeners: {[key: string]: Function} = {};
 
-  constructor(private renderer: Renderer) { }
+  constructor(
+    private renderer: Renderer,
+    private windowRef: SkyWindowRefService
+  ) { }
+
+  public ngOnDestroy() {
+    for (let key of Object.keys(this.parentListeners)) {
+      this.parentListeners[key]();
+      delete this.parentListeners[key];
+    }
+  }
 
   public setWaitBounds(waitEl: ElementRef) {
     this.renderer.setElementStyle(waitEl.nativeElement.parentElement, 'position', 'relative');
@@ -17,9 +32,64 @@ export class SkyWaitAdapterService {
     this.renderer.setElementStyle(waitEl.nativeElement.parentElement, 'position', undefined);
   }
 
-  public setBusyState(waitEl: ElementRef, isFullPage: boolean, isWaiting: boolean) {
+  public setBusyState(waitEl: ElementRef, isFullPage: boolean, isWaiting: boolean, id: string) {
     let busyEl = isFullPage ? document.body : waitEl.nativeElement.parentElement;
     let state = isWaiting ? 'true' : undefined;
     this.renderer.setElementAttribute(busyEl, 'aria-busy', state);
+
+    if (isWaiting) {
+      // Propagate tab navigation if attempted into waited element
+      if (!isFullPage) {
+        let focusListenerFunc = this.renderer.listen(this.windowRef.getWindow(), 'keyup', (event: any) => {
+          if (event.key.toLowerCase() === 'tab' && busyEl.contains(document.activeElement)) {
+            this.focusNextElement(busyEl, event.shiftKey);
+          }
+        });
+        this.parentListeners[id] = focusListenerFunc;
+      } else {
+        // Prevent tab navigation within the waited page
+        let endListenerFunc = this.renderer.listen(busyEl, 'keydown', (event: KeyboardEvent) => {
+          if (event.key.toLowerCase() === 'tab') {
+            event.preventDefault();
+          }
+        });
+        this.parentListeners[id] = endListenerFunc;
+      }
+    } else if (id in this.parentListeners) {
+      // Clean up existing listener
+      this.parentListeners[id]();
+      delete this.parentListeners[id];
+    }
+  }
+
+  private focusNextElement(parentElement: any, shiftKey: boolean): void {
+    // Select all possible focussable elements
+    let focussableElements =
+      'a[href], ' +
+      'area[href], ' +
+      'input:not([disabled]):not([tabindex=\'-1\']), ' +
+      'button:not([disabled]):not([tabindex=\'-1\']), ' +
+      'select:not([disabled]):not([tabindex=\'-1\']), ' +
+      'textarea:not([disabled]):not([tabindex=\'-1\']), ' +
+      'iframe, object, embed, ' +
+      '*[tabindex]:not([tabindex=\'-1\']), ' +
+      '*[contenteditable=true]';
+     let focussable = Array.prototype.filter.call(document.body.querySelectorAll(focussableElements),
+      (element: any) => {
+        return element.offsetWidth > 0 || element.offsetHeight > 0 || element === document.activeElement;
+      });
+     // If shift tab, go in the other direction
+    let modifier = 1;
+    if (shiftKey) {
+      modifier = -1;
+    }
+     // Find the next navigable element that isn't waiting
+    let curIndex = focussable.indexOf(document.activeElement) + modifier;
+    while (!focussable[curIndex] || parentElement.contains(focussable[curIndex]) || parentElement === focussable[curIndex]) {
+      curIndex += modifier;
+    }
+    if (focussable[curIndex]) {
+      focussable[curIndex].focus();
+    }
   }
 }

--- a/src/app/public/modules/wait/wait.component.spec.ts
+++ b/src/app/public/modules/wait/wait.component.spec.ts
@@ -1,7 +1,14 @@
 import {
   async,
-  TestBed
+  TestBed,
+  ComponentFixture,
+  tick,
+  fakeAsync
 } from '@angular/core/testing';
+
+import {
+  SkyAppTestUtility
+} from '@blackbaud/skyux-builder/runtime/testing/browser';
 
 import {
   expect
@@ -106,6 +113,52 @@ describe('Wait component', () => {
     expect(el.querySelector('.sky-wait-mask-loading-blocking')).toBeNull();
   });
 
+  it('should propagate tab navigation forward and backward avoiding waited element', fakeAsync(() => {
+    let fixture = TestBed.createComponent(SkyWaitTestComponent);
+    fixture.detectChanges();
+
+     fixture.componentInstance.isFullPage = false;
+    fixture.componentInstance.isWaiting = true;
+    fixture.detectChanges();
+
+    let anchor1: any = document.body.querySelector('#anchor-1');
+    let anchor2: any = document.body.querySelector('#anchor-2');
+    let button: any = document.querySelector('.sky-btn');
+    button.focus();
+    expect(document.activeElement).toBe(button);
+
+    SkyAppTestUtility.fireDomEvent(window, 'keyup', {
+      keyboardEventInit: { key: 'Tab' }
+    });
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+    expect(document.activeElement).toBe(anchor2);
+
+    button.focus();
+    SkyAppTestUtility.fireDomEvent(window, 'keyup', {
+      keyboardEventInit: { key: 'Tab', shiftKey: true }
+    });
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+    expect(document.activeElement).toBe(anchor1);
+
+    fixture.componentInstance.isWaiting = false;
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    button.focus();
+    SkyAppTestUtility.fireDomEvent(window, 'keyup', {
+      keyboardEventInit: { key: 'Tab' }
+    });
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+    expect(document.activeElement).toBe(button);
+  }));
+
   it('should set aria-busy on document body when fullPage is true', async(() => {
     let fixture = TestBed.createComponent(SkyWaitTestComponent);
 
@@ -138,5 +191,36 @@ describe('Wait component', () => {
     fixture.componentInstance.isWaiting = false;
     fixture.detectChanges();
     expect(el.querySelector('.sky-wait-test-component').getAttribute('aria-busy')).toBeNull();
+  });
+
+  let testlistenerCreated = (fixture: ComponentFixture<SkyWaitTestComponent>) => {
+    fixture.detectChanges();
+
+    let waitComponent: any = fixture.componentInstance.waitComponent;
+    let adapter: any = waitComponent.adapterService;
+    expect(waitComponent.id in adapter.parentListeners).toBeTruthy();
+    expect(Object.keys(adapter.parentListeners).length).toBe(1);
+
+    fixture.componentInstance.isWaiting = false;
+    fixture.detectChanges();
+    expect(waitComponent.id in adapter.parentListeners).toBeFalsy();
+    expect(Object.keys(adapter.parentListeners).length).toBe(0);
+  };
+
+  it('should create listener on document body when fullPage is true', () => {
+    let fixture = TestBed.createComponent(SkyWaitTestComponent);
+    fixture.detectChanges();
+
+    fixture.componentInstance.isFullPage = true;
+    fixture.componentInstance.isWaiting = true;
+    testlistenerCreated(fixture);
+  });
+
+  it('should create listener on containing div when fullPage is set to false', () => {
+    let fixture = TestBed.createComponent(SkyWaitTestComponent);
+    fixture.detectChanges();
+
+    fixture.componentInstance.isWaiting = true;
+    testlistenerCreated(fixture);
   });
 });

--- a/src/app/public/modules/wait/wait.component.ts
+++ b/src/app/public/modules/wait/wait.component.ts
@@ -8,6 +8,8 @@ import {
   SkyWaitAdapterService
 } from './wait-adapter.service';
 
+let nextId = 0;
+
 @Component({
   selector: 'sky-wait',
   templateUrl: './wait.component.html',
@@ -16,6 +18,8 @@ import {
 })
 export class SkyWaitComponent {
 
+  private id: string = `sky-wait-${++nextId}`;
+
   @Input()
   public set isWaiting(value: boolean) {
     if (value && !this._isFullPage) {
@@ -23,7 +27,7 @@ export class SkyWaitComponent {
     } else if (!value && !this._isFullPage) {
       this.adapterService.removeWaitBounds(this.elRef);
     }
-    this.adapterService.setBusyState(this.elRef, this._isFullPage, value);
+    this.adapterService.setBusyState(this.elRef, this._isFullPage, value, this.id);
     this._isWaiting = value;
   }
 

--- a/src/app/public/modules/wait/wait.service.spec.ts
+++ b/src/app/public/modules/wait/wait.service.spec.ts
@@ -9,6 +9,10 @@ import {
 } from '@angular/core/testing';
 
 import {
+  SkyAppTestUtility
+} from '@blackbaud/skyux-builder/runtime/testing/browser';
+
+import {
   SkyWaitFixturesModule
 } from './fixtures/wait-fixtures.module';
 
@@ -95,6 +99,21 @@ describe('Wait service', () => {
     applicationRef.tick();
     verifyBlockingPageWaitExists(false);
 
+  }));
+
+  it('should block tab navigation when a blocking page wait is active', fakeAsync(() => {
+    waitService.beginBlockingPageWait();
+    tick();
+    applicationRef.tick();
+     verifyBlockingPageWaitExists(true);
+    let button = document.body.querySelector('button');
+    button.focus();
+    expect(document.activeElement).toBe(button);
+     SkyAppTestUtility.fireDomEvent(document.body, 'keydown', {
+      keyboardEventInit: { key: 'tab' }
+    });
+    button = document.body.querySelector('button');
+    expect(document.activeElement).toBe(button);
   }));
 
   it('should add a nonblocking page wait when beginPageWait is called with isBlocking false',


### PR DESCRIPTION
Alright, I have a solution for the navigability for non-full-page waits as I mentioned in second standup. And It really needs some review or alternate opinions. Most of the work is in the `wait-adapter-service` file.

So the issue is that you can tab navigate into the tab navigable elements inside a waited element. There isn't a good straightforward way of preventing tab navigation within an element that I have come accross looking around. So I have 2 solution approaches for this.

1. Loop through all children, grandchildren, etc that are tab-navigable within an element and set their tabIndex to -1. Issues with this are:
 ```- it could become unweildy the larger the element is and more navigable children it has.
 - I would also have to log the previous tabIndex of each element so I could revert them completely when the wait is over.
 - This won't account for elements that are added after the wait begins unless I have it run off mutation events as well.
```

2. Event responses. (what I currently am doing)
I currently see 3 ways to go about this:
 ```- I can listen for focus events on the first(or the host itself) and last elements in the host element and shift focus to the next legitimate target.
 - I can put keydown events on the navigable elements before and after the host element to skip the host when tab navigation is attempted on either.
 - I can put a listener on the window for keyup events to check if focus has shifted to an element within the host and if it was caused by tab navigation. Then shift the focus to the next legitimate target.
```

The first two for this would also be susceptible to any mutations list new navigable elements being added before or after the host; or if the elements I listened to events on are removed.
So right now I have the window listener solution implemented.

If anyone has an idea I haven't considered yet or improvement ideas, I would love to hear them cause I still really don't like this implementation. In particular, I'm not fully confident in my selector for all tab navigable elements which seems to be required for all these solutions.
Really still kinda hoping that there is some magical attribute that blocks tab navigation on an element and it's descendants, but I haven't found one.

Resolves: #1580