### PR TITLE
Text highlight > mutation observer ignore attributes

### DIFF
--- a/src/app/public/modules/text-highlight/text-highlight.directive.ts
+++ b/src/app/public/modules/text-highlight/text-highlight.directive.ts
@@ -142,7 +142,7 @@ export class SkyTextHighlightDirective
 
   private observeDom() {
     if (this.observer) {
-      const config = { attributes: true, childList: true, characterData: true };
+      const config = { attributes: false, childList: true, characterData: true };
       this.observer.observe(this.el.nativeElement, config);
     }
   }


### PR DESCRIPTION
Highlight modifies attributes when a search is performed. However, the highlight directive observes attributes, so the observer is fired multiple times. This change tells the observer to ignores attribute.