### PR TITLE
Fixed chevron alignment in Firefox

### DIFF
--- a/src/app/public/modules/chevron/chevron.component.scss
+++ b/src/app/public/modules/chevron/chevron.component.scss
@@ -12,6 +12,7 @@
   width: $sky-context-menu-size;
   cursor: pointer;
   position: relative;
+  vertical-align: top;
 
   &:hover .sky-chevron-part {
     border-color: darken($sky-text-color-icon-borderless, 20%);


### PR DESCRIPTION
Firefox added a few pixels of space above the chevron in the latest release `3.0.1`. This will fix that.
Addresses: https://github.com/blackbaud/skyux-indicators/issues/32