### PR TITLE
Fix console warning during unit tests

### DIFF
--- a/src/app/public/modules/alert/alert.component.spec.ts
+++ b/src/app/public/modules/alert/alert.component.spec.ts
@@ -4,20 +4,8 @@ import {
 } from '@angular/core/testing';
 
 import {
-  BrowserModule
-} from '@angular/platform-browser';
-
-import {
   expect
 } from '@skyux-sdk/testing';
-
-import {
-  SkyLibResourcesService
-} from '@skyux/i18n';
-
-import {
-  SkyLibResourcesTestService
-} from '@skyux/i18n/testing';
 
 import {
   AlertTestComponent
@@ -34,14 +22,7 @@ describe('Alert component', () => {
         AlertTestComponent
       ],
       imports: [
-        BrowserModule,
         SkyAlertModule
-      ],
-      providers: [
-        {
-          provide: SkyLibResourcesService,
-          useClass: SkyLibResourcesTestService
-        }
       ]
     });
   });

--- a/src/app/public/modules/tokens/fixtures/tokens-fixtures.module.ts
+++ b/src/app/public/modules/tokens/fixtures/tokens-fixtures.module.ts
@@ -7,14 +7,6 @@ import {
 } from '@angular/common';
 
 import {
-  SkyLibResourcesService
-} from '@skyux/i18n';
-
-import {
-  SkyLibResourcesTestService
-} from '@skyux/i18n/testing';
-
-import {
   SkyTokensModule
 } from '../tokens.module';
 
@@ -32,12 +24,6 @@ import {
   ],
   exports: [
     SkyTokensTestComponent
-  ],
-  providers: [
-    {
-      provide: SkyLibResourcesService,
-      useClass: SkyLibResourcesTestService
-    }
   ]
 })
 export class SkyTokensFixturesModule { }

--- a/src/app/public/modules/tokens/tokens.module.ts
+++ b/src/app/public/modules/tokens/tokens.module.ts
@@ -7,6 +7,10 @@ import {
 } from '@angular/common';
 
 import {
+  SkyI18nModule
+} from '@skyux/i18n';
+
+import {
   SkyTokenComponent
 } from './token.component';
 
@@ -18,6 +22,10 @@ import {
   SkyIconModule
 } from '../icon/icon.module';
 
+import {
+  SkyIndicatorsResourcesModule
+} from '../shared/indicators-resources.module';
+
 @NgModule({
   declarations: [
     SkyTokenComponent,
@@ -25,7 +33,9 @@ import {
   ],
   imports: [
     CommonModule,
-    SkyIconModule
+    SkyI18nModule,
+    SkyIconModule,
+    SkyIndicatorsResourcesModule
   ],
   exports: [
     SkyTokenComponent,

--- a/src/app/public/modules/wait/wait.component.spec.ts
+++ b/src/app/public/modules/wait/wait.component.spec.ts
@@ -6,14 +6,6 @@ import {
 } from '@angular/core/testing';
 
 import {
-  SkyLibResourcesService
-} from '@skyux/i18n';
-
-import {
-  SkyLibResourcesTestService
-} from '@skyux/i18n/testing';
-
-import {
   expect,
   SkyAppTestUtility
 } from '@skyux-sdk/testing';
@@ -39,12 +31,6 @@ describe('Wait component', () => {
     TestBed.configureTestingModule({
       imports: [
         SkyWaitFixturesModule
-      ],
-      providers: [
-        {
-          provide: SkyLibResourcesService,
-          useClass: SkyLibResourcesTestService
-        }
       ]
     });
   });


### PR DESCRIPTION
This branch fixes the warning we receive during unit tests:
```
WARN: 'SkyLibResourcesTestService is no longer needed and should be removed from any TestBed modules that provide it.'
```