### PR TITLE
feat: add functions that will wrap observables w/ skywait

### DIFF
--- a/src/app/public/modules/wait/wait.service.spec.ts
+++ b/src/app/public/modules/wait/wait.service.spec.ts
@@ -14,12 +14,19 @@ import {
 } from '@skyux/core';
 
 import {
+  ReplaySubject
+} from 'rxjs';
+
+import {
   SkyWaitFixturesModule
 } from './fixtures/wait-fixtures.module';
 
 import {
   SkyWaitService
 } from './wait.service';
+
+const NO_OP_FUNC: () => void = () => {
+};
 
 describe('Wait service', () => {
   let waitService: SkyWaitService;
@@ -211,5 +218,83 @@ describe('Wait service', () => {
 
     verifyNonBlockingPageWaitExists(false);
     verifyBlockingPageWaitExists(false);
+  }));
+
+  it('should wrap with blocking wait when the given observable is hot', fakeAsync(() => {
+    const subject = new ReplaySubject();
+    waitService.blockingWrap(subject.asObservable()).subscribe(NO_OP_FUNC);
+    subject.next('A');
+    tick();
+    applicationRef.tick();
+    verifyBlockingPageWaitExists(true);
+    subject.complete();
+    tick();
+    applicationRef.tick();
+    verifyBlockingPageWaitExists(false);
+  }));
+
+  it('should not wrap with blocking wait when the given observable is cold', fakeAsync(() => {
+    const subject = new ReplaySubject();
+    waitService.blockingWrap(subject.asObservable());
+    subject.next('A');
+    tick();
+    applicationRef.tick();
+    verifyBlockingPageWaitExists(false);
+    subject.complete();
+    tick();
+    applicationRef.tick();
+    verifyBlockingPageWaitExists(false);
+  }));
+
+  it('should wrap with blocking wait when the given observable throws error', fakeAsync(() => {
+    const subject = new ReplaySubject();
+    waitService.blockingWrap(subject.asObservable()).subscribe(NO_OP_FUNC, NO_OP_FUNC);
+    subject.next('A');
+    tick();
+    applicationRef.tick();
+    verifyBlockingPageWaitExists(true);
+    subject.error('error');
+    tick();
+    applicationRef.tick();
+    verifyBlockingPageWaitExists(false);
+  }));
+
+  it('should wrap with nonblocking wait when the given observable is hot', fakeAsync(() => {
+    const subject = new ReplaySubject();
+    waitService.nonBlockingWrap(subject.asObservable()).subscribe(NO_OP_FUNC);
+    subject.next('A');
+    tick();
+    applicationRef.tick();
+    verifyNonBlockingPageWaitExists(true);
+    subject.complete();
+    tick();
+    applicationRef.tick();
+    verifyNonBlockingPageWaitExists(false);
+  }));
+
+  it('should not wrap with nonblocking wait when the given observable is cold', fakeAsync(() => {
+    const subject = new ReplaySubject();
+    waitService.nonBlockingWrap(subject.asObservable());
+    subject.next('A');
+    tick();
+    applicationRef.tick();
+    verifyNonBlockingPageWaitExists(false);
+    subject.complete();
+    tick();
+    applicationRef.tick();
+    verifyNonBlockingPageWaitExists(false);
+  }));
+
+  it('should wrap with nonblocking wait when the given observable throws error', fakeAsync(() => {
+    const subject = new ReplaySubject();
+    waitService.nonBlockingWrap(subject.asObservable()).subscribe(NO_OP_FUNC, NO_OP_FUNC);
+    subject.next('A');
+    tick();
+    applicationRef.tick();
+    verifyNonBlockingPageWaitExists(true);
+    subject.error('error');
+    tick();
+    applicationRef.tick();
+    verifyNonBlockingPageWaitExists(false);
   }));
 });

--- a/src/app/public/modules/wait/wait.service.ts
+++ b/src/app/public/modules/wait/wait.service.ts
@@ -9,12 +9,21 @@ import {
 } from '@skyux/core';
 
 import {
-  SkyWaitPageComponent
-} from './wait-page.component';
+  defer,
+  Observable
+} from 'rxjs';
+
+import {
+  finalize
+} from 'rxjs/operators';
 
 import {
   SkyWaitPageAdapterService
 } from './wait-page-adapter.service';
+
+import {
+  SkyWaitPageComponent
+} from './wait-page.component';
 
 // Need to add the following to classes which contain static methods.
 // See: https://github.com/ng-packagr/ng-packagr/issues/641
@@ -61,6 +70,20 @@ export class SkyWaitService {
       SkyWaitService.pageWaitNonBlockingCount = 0;
       this.waitAdapter.removePageWaitEl();
     }
+  }
+
+  public blockingWrap<T>(observable: Observable<T>): Observable<T> {
+    return defer(() => {
+      this.beginBlockingPageWait();
+      return observable.pipe(finalize(() => this.endBlockingPageWait()));
+    });
+  }
+
+  public nonBlockingWrap<T>(observable: Observable<T>): Observable<T> {
+    return defer(() => {
+      this.beginNonBlockingPageWait();
+      return observable.pipe(finalize(() => this.endNonBlockingPageWait()));
+    });
   }
 
   private setWaitComponentProperties(isBlocking: boolean): void {

--- a/src/app/public/modules/wait/wait.service.ts
+++ b/src/app/public/modules/wait/wait.service.ts
@@ -9,13 +9,8 @@ import {
 } from '@skyux/core';
 
 import {
-  defer,
   Observable
-} from 'rxjs';
-
-import {
-  finalize
-} from 'rxjs/operators';
+} from 'rxjs/Observable';
 
 import {
   SkyWaitPageAdapterService
@@ -24,6 +19,9 @@ import {
 import {
   SkyWaitPageComponent
 } from './wait-page.component';
+
+import 'rxjs/add/operator/finally';
+import 'rxjs/add/observable/defer';
 
 // Need to add the following to classes which contain static methods.
 // See: https://github.com/ng-packagr/ng-packagr/issues/641
@@ -73,16 +71,16 @@ export class SkyWaitService {
   }
 
   public blockingWrap<T>(observable: Observable<T>): Observable<T> {
-    return defer(() => {
+    return Observable.defer(() => {
       this.beginBlockingPageWait();
-      return observable.pipe(finalize(() => this.endBlockingPageWait()));
+      return observable.finally(() => this.endBlockingPageWait());
     });
   }
 
   public nonBlockingWrap<T>(observable: Observable<T>): Observable<T> {
-    return defer(() => {
+    return Observable.defer(() => {
       this.beginNonBlockingPageWait();
-      return observable.pipe(finalize(() => this.endNonBlockingPageWait()));
+      return observable.finally(() => this.endNonBlockingPageWait());
     });
   }
 


### PR DESCRIPTION
it's common to want to wrap an observable in the wait service, particularly when making an http call. i.e. you want to show the blocking spinner while a backend call is happening. this makes that paradigm simple and avoids people having to duplicate that pattern throughout their code. 

expected usage:

```typescript
waitSvc.blockingWrap(http.get('url')).subscribe(doStuff);
```

credit to Nicklaus Glyder for the idea.