### PR TITLE
Remove undefined template variable

### DIFF
--- a/src/app/public/modules/tokens/tokens.component.html
+++ b/src/app/public/modules/tokens/tokens.component.html
@@ -4,7 +4,6 @@
 >
   <sky-token *ngFor="let token of tokens; let i = index"
     role="listitem"
-    [ariaLabel]="ariaLabel"
     [disabled]="disabled"
     [dismissible]="dismissible"
     [focusable]="focusable"


### PR DESCRIPTION
- The `ariaLabel` property doesn't exist on the `sky-tokens` component class.