### PR TITLE
Support double-click to highlight keyinfo value/label individually

### DIFF
--- a/src/app/public/modules/key-info/key-info.component.html
+++ b/src/app/public/modules/key-info/key-info.component.html
@@ -12,6 +12,7 @@
     >
     </ng-content>
   </div>
+
   <div
     class="sky-key-info-label sky-field-label"
   >


### PR DESCRIPTION
div tags without a separating character (newline or space, for example) causes a "double-click" to highlight the first word of the second div. Add a newline after the bb-key-info-value div to prevent the first word in the bb-key-info-label div from being highlighted on double-click. Likewise, this prevents the last word of the bb-key-info-value div from being highlighted upon double-click of the bb-key-info-label div.

This is re-produceable in latest version of Edge and Chrome on Windows 10. I have tested the fix in both browsers.

Alternative to a newline after the bb-key-info-value would be a single space after the first div. That may be more readable to future maintainers.

I'll leave it up to maintainers as to which is preferred (space vs newline).