### PR TITLE
feat: use aria-label instead of title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.7.1 (2020-10-23)
+
+- Fixed the help-inline component to avoid hover clashes when used in a hover-based popover. [#148](https://github.com/blackbaud/skyux-indicators/pull/148)
+
 # 4.7.0 (2020-10-22)
 
 - Updated the height of the token component in the modern theme. [#149](https://github.com/blackbaud/skyux-indicators/pull/149)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/indicators",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/indicators",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "description": "SKY UX Indicators",
   "scripts": {
     "build": "skyux build-public-library",

--- a/src/app/public/modules/help-inline/help-inline.component.html
+++ b/src/app/public/modules/help-inline/help-inline.component.html
@@ -1,7 +1,7 @@
 <button
   class="sky-help-inline"
   type="button"
-  [attr.title]="'skyux_help_inline_button_title' | skyLibResources"
+  [attr.aria-label]="'skyux_help_inline_button_title' | skyLibResources"
   (click)="onClick()"
 >
   <sky-icon


### PR DESCRIPTION
the use of title results in a use case where the label is shown on
hover, which ends up clashing when this component is used in conjunction
with a hover-based popover. using label keeps it accessible but avoids
the clash. and label seems preferred from a browser standpoint.

![2020-10-16 14 29 50](https://user-images.githubusercontent.com/28735029/96920601-fa1d8d00-1472-11eb-8337-1a47678ea165.gif)
