### PR TITLE
Update Font Awesome links to 4.7

### DIFF
--- a/src/app/docs/icon/icon-docs.component.html
+++ b/src/app/docs/icon/icon-docs.component.html
@@ -4,7 +4,7 @@
   pageTitle="Icon"
 >
   <sky-docs-demo-page-summary>
-    The icon component displays a <a href="https://fontawesome.com">Font Awesome icon</a> or a custom SKY UX icon.
+    The icon component displays a Font Awesome icon or a custom SKY UX icon.
   </sky-docs-demo-page-summary>
 
   <sky-docs-demo>
@@ -121,7 +121,7 @@
       heading="Dictionary"
     >
       <p>
-        The icon dictionary provides a complete list of icons that we recommend for use in SKY UX. All the icons are from <a href="http://fontawesome.io">Font Awesome</a>, and we support version 4.7.0. If Font Awesome does not have a particular icon, it is probably not common enough for its purpose to be immediately obvious to users.
+        The icon dictionary provides a complete list of the Font Awesome icons that we recommend for use in SKY UX. We support <a href="https://fontawesome.com/v4.7/icons/">Font Awesome version 4.7.0</a>. If Font Awesome does not have a particular icon, it is probably not common enough for its purpose to be immediately obvious to users.
       </p>
     </sky-docs-demo-page-section>
 

--- a/src/app/public/modules/icon/icon-stack-item.ts
+++ b/src/app/public/modules/icon/icon-stack-item.ts
@@ -2,7 +2,7 @@ export interface SkyIconStackItem {
 
   /**
    * Specifies the name of
-   * [the Font Awesome icon](https://fontawesome.com/icons?d=gallery) to
+   * [the Font Awesome 4.7 icon](https://fontawesome.com/v4.7/icons/) to
    * display. Do not specify the `fa fa-` classes.
    * @required
    */

--- a/src/app/public/modules/icon/icon.component.ts
+++ b/src/app/public/modules/icon/icon.component.ts
@@ -18,7 +18,7 @@ export class SkyIconComponent {
 
   /**
    * Specifies the name of
-   * [the Font Awesome icon](https://fontawesome.com/icons?d=gallery) to
+   * [the Font Awesome 4.7 icon](https://fontawesome.com/v4.7/icons/) to
    * display. Do not specify the `fa fa-` classes.
    * @required
    */


### PR DESCRIPTION
Address consumer recommendation to make Font Awesome links 4.7-specific.