### PR TITLE
Added displayOnly input to the chevron component

### DIFF
--- a/projects/indicators/src/modules/chevron/chevron.component.html
+++ b/projects/indicators/src/modules/chevron/chevron.component.html
@@ -1,4 +1,5 @@
 <button
+  *ngIf="!displayOnly"
   class="sky-chevron"
   type="button"
   [attr.aria-controls]="ariaControls"
@@ -20,6 +21,25 @@
     </span>
   </ng-container>
 </button>
+
+<div
+  *ngIf="displayOnly"
+  class="sky-chevron"
+  [attr.aria-hidden]="true"
+  [ngClass]="['sky-chevron-' + direction]"
+  [skyThemeClass]="{
+    'sky-btn sky-btn-icon-borderless': 'modern'
+  }"
+>
+  <ng-container *skyThemeIf="'default'">
+    <ng-container *ngTemplateOutlet="icon"></ng-container>
+  </ng-container>
+  <ng-container *skyThemeIf="'modern'">
+    <span class="chevron-glyph-container">
+      <ng-container *ngTemplateOutlet="icon"></ng-container>
+    </span>
+  </ng-container>
+</div>
 
 <ng-template #icon>
   <i aria-hidden="true" class="sky-chevron-part sky-chevron-left"> </i>

--- a/projects/indicators/src/modules/chevron/chevron.component.html
+++ b/projects/indicators/src/modules/chevron/chevron.component.html
@@ -27,9 +27,6 @@
   class="sky-chevron"
   [attr.aria-hidden]="true"
   [ngClass]="['sky-chevron-' + direction]"
-  [skyThemeClass]="{
-    'sky-btn sky-btn-icon-borderless': 'modern'
-  }"
 >
   <ng-container *skyThemeIf="'default'">
     <ng-container *ngTemplateOutlet="icon"></ng-container>

--- a/projects/indicators/src/modules/chevron/chevron.component.html
+++ b/projects/indicators/src/modules/chevron/chevron.component.html
@@ -1,5 +1,5 @@
 <button
-  *ngIf="!displayOnly"
+  *ngIf="!iconOnly"
   class="sky-chevron"
   type="button"
   [attr.aria-controls]="ariaControls"
@@ -23,7 +23,7 @@
 </button>
 
 <div
-  *ngIf="displayOnly"
+  *ngIf="iconOnly"
   class="sky-chevron"
   [attr.aria-hidden]="true"
   [ngClass]="['sky-chevron-' + direction]"

--- a/projects/indicators/src/modules/chevron/chevron.component.scss
+++ b/projects/indicators/src/modules/chevron/chevron.component.scss
@@ -16,14 +16,14 @@ button {
   width: $sky-context-menu-size;
   position: relative;
   vertical-align: top;
-
-  &:hover .sky-chevron-part {
-    border-color: darken($sky-text-color-icon-borderless, 20%);
-  }
 }
 
 button.sky-chevron {
   cursor: pointer;
+
+  &:hover .sky-chevron-part {
+    border-color: darken($sky-text-color-icon-borderless, 20%);
+  }
 }
 
 .sky-chevron-part {

--- a/projects/indicators/src/modules/chevron/chevron.component.scss
+++ b/projects/indicators/src/modules/chevron/chevron.component.scss
@@ -14,13 +14,16 @@ button {
   margin: 0;
   overflow: hidden;
   width: $sky-context-menu-size;
-  cursor: pointer;
   position: relative;
   vertical-align: top;
 
   &:hover .sky-chevron-part {
     border-color: darken($sky-text-color-icon-borderless, 20%);
   }
+}
+
+button.sky-chevron {
+  cursor: pointer;
 }
 
 .sky-chevron-part {

--- a/projects/indicators/src/modules/chevron/chevron.component.spec.ts
+++ b/projects/indicators/src/modules/chevron/chevron.component.spec.ts
@@ -22,9 +22,13 @@ describe('Chevron component', () => {
     fixture = TestBed.createComponent(SkyChevronComponent);
   });
 
+  function getChevronEl(): HTMLElement {
+    return fixture.nativeElement.querySelector('.sky-chevron');
+  }
+
   function validateDirection(expectedDirection: string): void {
     const el = fixture.nativeElement;
-    const chevronEl = el.querySelector('.sky-chevron');
+    const chevronEl = getChevronEl();
 
     fixture.detectChanges();
 
@@ -35,7 +39,7 @@ describe('Chevron component', () => {
   }
 
   function clickChevron(el: any): void {
-    el.querySelector('.sky-chevron').click();
+    getChevronEl().click();
   }
 
   it('should change direction when the user clicks the chevron', () => {
@@ -92,10 +96,50 @@ describe('Chevron component', () => {
     expect(buttonEl.getAttribute('aria-expanded')).toBe('false');
   });
 
+  it('should be a focusable element', () => {
+    fixture.detectChanges();
+    const chevronWrapperEl = getChevronEl();
+    chevronWrapperEl.focus();
+
+    expect(document.activeElement).toEqual(chevronWrapperEl);
+  });
+
+  it('should not have an aria-hidden attribute', () => {
+    fixture.detectChanges();
+    const chevronWrapperEl = getChevronEl();
+
+    expect(chevronWrapperEl.getAttribute('aria-hidden')).toBeNull();
+  });
+
   it('should pass accessibility', async () => {
     fixture.componentInstance.ariaLabel = 'Users';
     fixture.detectChanges();
     await fixture.whenStable();
     await expectAsync(fixture.nativeElement).toBeAccessible();
+  });
+
+  describe('in displayOnly mode', () => {
+    beforeEach(() => {
+      fixture.componentInstance.displayOnly = true;
+      fixture.detectChanges();
+    });
+
+    it('should not be a focusable element', () => {
+      const chevronWrapperEl = getChevronEl();
+      chevronWrapperEl.focus();
+
+      expect(document.activeElement).not.toEqual(chevronWrapperEl);
+    });
+
+    it('should set aria-hidden to true', () => {
+      const chevronWrapperEl = getChevronEl();
+
+      expect(chevronWrapperEl.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    it('should pass accessibility', async () => {
+      await fixture.whenStable();
+      await expectAsync(fixture.nativeElement).toBeAccessible();
+    });
   });
 });

--- a/projects/indicators/src/modules/chevron/chevron.component.spec.ts
+++ b/projects/indicators/src/modules/chevron/chevron.component.spec.ts
@@ -118,9 +118,9 @@ describe('Chevron component', () => {
     await expectAsync(fixture.nativeElement).toBeAccessible();
   });
 
-  describe('in displayOnly mode', () => {
+  describe('in iconOnly mode', () => {
     beforeEach(() => {
-      fixture.componentInstance.displayOnly = true;
+      fixture.componentInstance.iconOnly = true;
       fixture.detectChanges();
     });
 

--- a/projects/indicators/src/modules/chevron/chevron.component.ts
+++ b/projects/indicators/src/modules/chevron/chevron.component.ts
@@ -49,10 +49,10 @@ export class SkyChevronComponent {
   public disabled = false;
 
   /**
-   * Indicates whether the chevron button should be displayed as a non-interactable element.
+   * Indicates whether to display the chevron as an icon instead of a button.
    */
   @Input()
-  public displayOnly = false;
+  public iconOnly = false;
 
   /**
    * Fires when the direction of the chevron changes.

--- a/projects/indicators/src/modules/chevron/chevron.component.ts
+++ b/projects/indicators/src/modules/chevron/chevron.component.ts
@@ -49,6 +49,12 @@ export class SkyChevronComponent {
   public disabled = false;
 
   /**
+   * Indicates whether the chevron button should be displayed as a non-interactable element.
+   */
+  @Input()
+  public displayOnly = false;
+
+  /**
    * Fires when the direction of the chevron changes.
    */
   @Output()


### PR DESCRIPTION
The groups in [vertical tabs](https://developer.blackbaud.com/skyux-tabs/docs/vertical-tabs?docs-active-tab=design) should follow the [accordion](https://www.w3.org/TR/wai-aria-practices/#accordion) pattern. To do so, we need a visual-only representation of the chevron since the entire group element will be the interactive element. Without this, both the heading and chevron would be interactive and do the same thing, adding noise to the accessibility API.